### PR TITLE
add more data model methods to bool

### DIFF
--- a/ruamel_yaml_line_info/constructor.py
+++ b/ruamel_yaml_line_info/constructor.py
@@ -160,6 +160,14 @@ class ScalarBoolean(ruamel.yaml.scalarbool.ScalarBoolean):
         ret_val.lc = None
         return ret_val
 
+    def __bool__(self) -> bool:
+        """Provide a real bool value."""
+        return False if self == 0 else True
+
+    def __repr__(self) -> str:
+        """Provide a real bool representation."""
+        return "True" if self else "False"
+
 
 class ScalarFloat(ruamel.yaml.scalarfloat.ScalarFloat):
     """Sub-class of to store line numbers."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -205,3 +205,24 @@ def test_comment() -> None:
     data = yaml.load("foo:\n  # some comment\n  bar: cow\n")
     assert str(data) == "{'foo': {'bar': 'cow'}}"
     assert data["foo"].ca.comment[1][0].value == "# some comment\n"
+
+
+@pytest.mark.parametrize(
+    ("in_text", "parsed_as", "out_repr"),
+    [
+        ("true", True, "True"),
+        ("false", False, "False"),
+        ("0", 0, "0"),
+        ("1", 1, "1"),
+        ("1.1", 1.1, "1.1"),
+        ("'bar'", "bar", "'bar'"),
+    ],
+)
+def test_basic_types(in_text: str, parsed_as: Any, out_repr: str) -> None:
+    """Tests basic in-flight and represented parsing."""
+    yaml = ruamel_yaml_line_info.YAML(typ="rt", pure=True)
+    data = yaml.load(f"foo: {in_text}")
+    assert data["foo"] == parsed_as
+    lc = data["foo"].lc
+    assert (lc.line, lc.col) == (0, 5)
+    assert str(data) == f"{{'foo': {out_repr}}}"


### PR DESCRIPTION
Thanks again for this tool!

This adds a few dunder methods to the `ScalarBoolean` type that will at least fool _more_ things, such as: 
- `jsonschema.validate(parsed_bool, {"type": "boolean"})`
- `print(parsed_bool)`

It _won't_ handle:

- `json.dumps(parsed_bool)` (still gets 1 or 0)
  - but I couldn't see a way to do that without an extended encoder.
- `parsed_bool is True`
  - there can be only one 
- `isinstance(parsed_bool)`
  - `bool` can't be subclassed

Happy to add more tests, if so desired: i didn't want to touch the dependencies, but would ideally add `jsonschema`.